### PR TITLE
AND-8515 - Change the compile gradle statement with implementation

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.library'
 group = 'com.github.douglasjunior'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion SDKVersion
+    buildToolsVersion BToolsVersion
 
     defaultConfig {
         minSdkVersion 7
@@ -41,8 +41,8 @@ buildscript {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-annotations:23.2.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:support-annotations:23.2.1'
 }
 
 // build a jar with source files


### PR DESCRIPTION
The compile keyword is going to be removed by the end of 2018
Also, start using common buildTools and support library